### PR TITLE
Update remark

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@
 [![Plugin installs!](https://img.shields.io/apm/dm/linter-markdown.svg)](https://atom.io/packages/linter-markdown)
 [![Package version!](https://img.shields.io/apm/v/linter-markdown.svg?style=flat)](https://atom.io/packages/linter-markdown)
 
-Lint markdown files utilizing [mdast-lint][mdast-lint] and the [linter][linter] package for atom.
+Lint markdown files utilizing [remark-lint][remark-lint] and the [linter][linter] package for atom.
 
-The linting is easily [configurable][configuration] with mdast-lint.
+The linting is easily [configurable][configuration] with remark-lint.
 
 We also maintain a [changelog][changelog] containing recent changes.
 
 ![Screenshot of linter-markdown in action][screenshot]
 
-[mdast-lint]: https://github.com/wooorm/mdast-lint
+[remark-lint]: https://github.com/wooorm/remark-lint
 [changelog]: https://github.com/AtomLinter/linter-markdown/blob/master/CHANGELOG.md
-[configuration]: https://github.com/wooorm/mdast-lint#configuring-mdast-lint
+[configuration]: https://github.com/wooorm/remark-lint#configuring-remark-lint
 [linter]: https://atom.io/packages/linter
 [screenshot]: https://raw.githubusercontent.com/AtomLinter/linter-markdown/master/assets/screenshot.png

--- a/lib/linter.coffee
+++ b/lib/linter.coffee
@@ -1,7 +1,7 @@
 path = require('path')
 
 # Lazy loading these
-mdast = null
+remark = null
 lint = null
 
 getRange = (range) ->
@@ -13,7 +13,7 @@ getRange = (range) ->
   r[1][1] = m[2] * 1
   r
 
-Configuration = require '../node_modules/mdast/lib/cli/configuration.js'
+Configuration = require '../node_modules/remark/lib/cli/configuration.js'
 
 errorLoadingConfig = (error, filePath) ->
   return new Promise (resolve, reject) ->
@@ -26,7 +26,7 @@ errorLoadingConfig = (error, filePath) ->
 
 module.exports = new class # This only needs to be a class to bind lint()
   grammarScopes: ['source.gfm', 'source.pfm', 'text.md']
-  name: "mdast-lint"
+  name: "remark-lint"
   scope: "file"
   lintOnFly: true
 
@@ -48,15 +48,15 @@ module.exports = new class # This only needs to be a class to bind lint()
         }
 
       # Lazy loading required plugins
-      mdast ?= require 'mdast'
-      lint ?= require 'mdast-lint'
+      remark ?= require 'remark'
+      lint ?= require 'remark-lint'
 
       source = TextEditor.getText()
 
       new Promise (resolve, reject) ->
-        # Load .mdastrc config for current file
+        # Load .remarkrc config for current file
         # TODO: Instead of constructing a configuration every time,
-        # we should maybe watch .mdastrc files. But file watching
+        # we should maybe watch .remarkrc files. But file watching
         # with atom can be a PIA, so we do not that right now
         fin = new Configuration {detectRC: true}
         conf = fin.getConfiguration filePath, (err, conf) ->
@@ -65,7 +65,7 @@ module.exports = new class # This only needs to be a class to bind lint()
             return
 
           # Load processor for current path
-          processor = mdast().use(lint, conf.plugins.lint)
+          processor = remark().use(lint, conf.plugins.lint)
           processor.process source, conf.settings, (err, res, file) ->
             reject(err) if err
             resolve(res.messages.map(transform))

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "linter-markdown",
   "main": "./lib/init",
   "version": "1.2.4",
-  "description": "Lint markdown on the fly, using mdast-lint",
+  "description": "Lint markdown on the fly, using remark-lint",
   "scripts": {
-    "lint": "mdast -u mdast-lint README.md LICENSE.md",
+    "lint": "remark -u remark-lint README.md LICENSE.md",
     "test": "echo 'no tests'"
   },
   "keywords": [],
@@ -15,8 +15,8 @@
     "atom": "^1.0.0"
   },
   "dependencies": {
-    "mdast": "^2.3.0",
-    "mdast-lint": "^1.1.0"
+    "remark": "^3.0.0",
+    "remark-lint": "^2.0.0"
   },
   "providedServices": {
     "linter": {


### PR DESCRIPTION
This branch update mdast to version 3.0.0, which includes a rename to `remark`.
Additionally, mdast-lint is updated to 2.0.0, including a name-change to `remark-lint`.

Supersedes GH-19.
Closes GH-19.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-markdown/20)
<!-- Reviewable:end -->
