### PR TITLE
Fix the linter name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -128,7 +128,7 @@ function linter() {
 
   return {
     grammarScopes: ['source.gfm', 'source.pfm', 'text.md'],
-    name: 'linter-markdown',
+    name: 'remark-lint',
     scope: 'file',
     lintOnFly: true,
     lint: onchange


### PR DESCRIPTION
Generally linter plugins specify the name of the linter they are acting as a wrapper around instead of their package name.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-markdown/25)
<!-- Reviewable:end -->
