### PR TITLE
Pin remark and remark-lint versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "dependencies": {
     "atom-package-deps": "^4.0.1",
     "load-plugin": "^1.0.0",
-    "remark": "^4.0.0",
-    "remark-lint": "^3.0.0"
+    "remark": "4.2.2",
+    "remark-lint": "3.2.1"
   },
   "devDependencies": {
     "eslint": "^2.9.0",


### PR DESCRIPTION
Pin the versions of the remark packages so notifications are sent with new releases, and users can be kept more up to date.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-markdown/67)
<!-- Reviewable:end -->
