### PR TITLE
Option to disable linting without .remarkrc

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,9 @@
  * @fileoverview Linter.
  */
 
+const path = require('path');
+const fs = require('fs');
+
 const Configuration = require('remark/lib/cli/configuration.js');
 const loadPlugin = require('load-plugin');
 
@@ -88,8 +91,22 @@ function linter() {
    */
   function onchange(editor) {
     const filePath = editor.getPath();
+    const disabledWithoutConfig = atom.config.get('linter-markdown.disableWhenNoRemarkConfig');
 
-    if (!filePath) {
+    let configExists;
+    atom.project.getPaths().forEach(p => {
+      if (filePath.indexOf(p) > -1) {
+        try {
+          if (fs.lstatSync(path.join(p, '.remarkrc')).isFile()) {
+            configExists = true;
+          }
+        } catch (err) {
+          //
+        }
+      }
+    });
+
+    if (!filePath || (disabledWithoutConfig && !configExists)) {
       return Promise.resolve([]);
     }
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,13 @@
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
   },
+  "configSchema": {
+    "disableWhenNoRemarkConfig": {
+      "type": "boolean",
+      "default": false,
+      "title": "Disable when .remarkrc is not found at project root"
+    }
+  },
   "dependencies": {
     "atom-package-deps": "^4.0.1",
     "load-plugin": "^1.0.0",


### PR DESCRIPTION
An attempt to address GH-57 - also first pull request on an Atom package, so open to discussion of any issues in this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-markdown/91)
<!-- Reviewable:end -->
