### PR TITLE
Remove macOS testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,10 @@ after_script:
   - npm run lint
 
 ### Generic setup follows ###
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+script:
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
 
 # Needed to disable the auto-install step running `npm install`
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
 
 os:
   - linux
-  - osx
 
 after_script:
   - npm run lint


### PR DESCRIPTION
Travis-CI has become completely unusable for macOS testing, with builds consistently taking over 2 hours to finish queueing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/atomlinter/linter-markdown/126)
<!-- Reviewable:end -->
