### PR TITLE
Defer dependency loading

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,13 +14,27 @@ import { CompositeDisposable } from 'atom';
 const path = require('path');
 const config = require('./config');
 
+// Internal variables
 let engine;
 let processor;
 let subscriptions;
+
+// Settings
 let scopes;
 let detectIgnore;
 
-function lint(editor) {
+const waitOnIdle = () =>
+  new Promise((resolve) => {
+    // Idle callbacks are done in FIFO order, so waiting on a newly queued idle
+    // callback will ensure that the activation processes are completed
+    window.requestIdleCallback(resolve);
+  });
+
+async function lint(editor) {
+  if (!processor) {
+    await waitOnIdle();
+  }
+
   return engine({
     processor,
     detectIgnore,
@@ -39,14 +53,6 @@ function lint(editor) {
  * @return {LinterConfiguration}
  */
 function provideLinter() {
-  if (!engine) {
-    engine = require('unified-engine-atom');
-  }
-
-  if (!processor) {
-    processor = require('remark');
-  }
-
   return {
     grammarScopes: scopes,
     name: 'remark-lint',
@@ -57,7 +63,18 @@ function provideLinter() {
 }
 
 function activate() {
-  require('atom-package-deps').install('linter-markdown');
+  const installLinterMarkdownDeps = () => {
+    // Install package dependencies
+    if (!atom.inSpecMode()) {
+      require('atom-package-deps').install('linter-markdown');
+    }
+    // Load required modules
+    engine = require('unified-engine-atom');
+    processor = require('remark');
+  };
+
+  // Defer this till an idle time as we don't need it immediately
+  window.requestIdleCallback(installLinterMarkdownDeps);
 
   subscriptions = new CompositeDisposable();
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,9 +8,9 @@
  * @fileoverview Linter.
  */
 
-/* eslint-disable import/no-extraneous-dependencies, import/no-unresolved */
+// eslint-disable-next-line import/no-extraneous-dependencies, import/extensions
+import { CompositeDisposable } from 'atom';
 
-const CompositeDisposable = require('atom').CompositeDisposable;
 const path = require('path');
 const config = require('./config');
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
       "atom": true
     },
     "env": {
-      "node": true
+      "node": true,
+      "browser": true
     }
   },
   "providedServices": {

--- a/package.json
+++ b/package.json
@@ -38,18 +38,25 @@
   "eslintConfig": {
     "rules": {
       "comma-dangle": [
-        2,
+        "error",
         "never"
       ],
-      "global-require": 0,
-      "no-console": 0
+      "global-require": "off",
+      "no-console": "off",
+      "import/no-unresolved": [
+        "error",
+        {
+          "ignore": [
+            "atom"
+          ]
+        }
+      ]
     },
     "extends": "airbnb-base",
     "globals": {
       "atom": true
     },
     "env": {
-      "es6": true,
       "node": true
     }
   },


### PR DESCRIPTION
As Atom initializes any service providers as part of package activation, moving the requires in there wasn't actually saving us any time. Move the initialization of these requires into an idle callback triggered from the activate() call, and ensure they are ready before use.

This brings activation time from ~500 ms down to ~10 ms. A further ~6 ms can be shaved off by bringing the code from `config.js` into the main file, but that will need updating/refactoring of the remark engine.
