### PR TITLE
Async-ify the specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "^3.13.0",
     "eslint-config-airbnb-base": "^11.0.1",
     "eslint-plugin-import": "^2.2.0",
+    "jasmine-fix": "^1.0.1",
     "remark-cli": "^3.0.0"
   },
   "eslintConfig": {

--- a/spec/linter-markdown-spec.js
+++ b/spec/linter-markdown-spec.js
@@ -1,60 +1,49 @@
 'use babel';
 
 import * as path from 'path';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { beforeEach, it } from 'jasmine-fix';
+// NOTE: If using fit you must add it to the list above!
+
 import * as lint from '..';
 
+const validPath = path.join(__dirname, 'fixtures', 'definition-use-valid.md');
+const invalidPath = path.join(__dirname, 'fixtures', 'definition-use-invalid.md');
+
 describe('The remark-lint provider for Linter', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     atom.workspace.destroyActivePaneItem();
-    waitsForPromise(() => {
-      atom.packages.activatePackage('linter-markdown');
-      return atom.packages.activatePackage('language-gfm').then(() =>
-        atom.workspace.open(path.join(__dirname, 'fixtures', 'definition-use-valid.md'))
-      );
-    });
+    await atom.packages.activatePackage('linter-markdown');
+    await atom.packages.activatePackage('language-gfm');
   });
 
   describe('checks a file with issues and', () => {
     let editor = null;
-    const invalidPath = path.join(__dirname, 'fixtures', 'definition-use-invalid.md');
-    beforeEach(() => {
-      waitsForPromise(() =>
-        atom.workspace.open(invalidPath).then((openEditor) => { editor = openEditor; })
-      );
+    beforeEach(async () => {
+      editor = await atom.workspace.open(invalidPath);
     });
 
-    it('finds at least one message', () => {
-      waitsForPromise(() =>
-        lint.provideLinter().lint(editor).then(messages =>
-          expect(messages.length).toBeGreaterThan(0)
-        )
-      );
+    it('finds at least one message', async () => {
+      const messages = await lint.provideLinter().lint(editor);
+      expect(messages.length).toBeGreaterThan(0);
     });
 
-    it('verifies the first message', () => {
-      waitsForPromise(() =>
-        lint.provideLinter().lint(editor).then((messages) => {
-          expect(messages[0].type).toEqual('Warning');
-          expect(messages[0].text).not.toBeDefined();
-          expect(messages[0].html).toEqual(
-            '<span class="badge badge-flexible">remark-lint:' +
-            'no-unused-definitions</span> Found unused definition'
-          );
-          expect(messages[0].filePath).toMatch(/.+definition-use-invalid\.md$/);
-          expect(messages[0].range).toEqual([[2, 0], [2, 58]]);
-        })
+    it('verifies the first message', async () => {
+      const messages = await lint.provideLinter().lint(editor);
+      expect(messages[0].type).toEqual('Warning');
+      expect(messages[0].text).not.toBeDefined();
+      expect(messages[0].html).toEqual(
+        '<span class="badge badge-flexible">remark-lint:' +
+        'no-unused-definitions</span> Found unused definition'
       );
+      expect(messages[0].filePath).toMatch(/.+definition-use-invalid\.md$/);
+      expect(messages[0].range).toEqual([[2, 0], [2, 58]]);
     });
   });
 
-  it('finds nothing wrong with a valid file', () => {
-    const validPath = path.join(__dirname, 'fixtures', 'definition-use-valid.md');
-    waitsForPromise(() =>
-      atom.workspace.open(validPath).then(editor =>
-        lint.provideLinter().lint(editor).then(messages =>
-          expect(messages.length).toBe(0)
-        )
-      )
-    );
+  it('finds nothing wrong with a valid file', async () => {
+    const editor = await atom.workspace.open(validPath);
+    const messages = await lint.provideLinter().lint(editor);
+    expect(messages.length).toBe(0);
   });
 });


### PR DESCRIPTION
Bring in `async` compatible versions of `beforeEach` and `it` from the `jasmine-fix` module and refactor the code accordingly.