### PR TITLE
Minor fixes to callback handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -99,6 +99,7 @@ function activate() {
 
 function deactivate() {
   idleCallbacks.forEach(callbackID => window.cancleIdleCallback(callbackID));
+  idleCallbacks.clear();
   subscriptions.dispose();
 
   config.off();

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,20 +24,13 @@ const idleCallbacks = new Set();
 let scopes;
 let detectIgnore;
 
-const waitOnIdle = () =>
-  new Promise((resolve) => {
-    // Idle callbacks are done in FIFO order, so waiting on a newly queued idle
-    // callback will ensure that the activation processes are completed
-    const callbackID = window.requestIdleCallback(() => {
-      idleCallbacks.delete(callbackID);
-      resolve();
-    });
-    idleCallbacks.add(callbackID);
-  });
-
-async function lint(editor) {
+function lint(editor) {
+  // Load required modules if not already handled by init
+  if (!engine) {
+    engine = require('unified-engine-atom');
+  }
   if (!processor) {
-    await waitOnIdle();
+    processor = require('remark');
   }
 
   return engine({
@@ -77,8 +70,12 @@ function activate() {
       require('atom-package-deps').install('linter-markdown');
     }
     // Load required modules
-    engine = require('unified-engine-atom');
-    processor = require('remark');
+    if (!engine) {
+      engine = require('unified-engine-atom');
+    }
+    if (!processor) {
+      processor = require('remark');
+    }
   };
 
   // Defer this till an idle time as we don't need it immediately


### PR DESCRIPTION
Fixes two minor things:
* Remove references to current `idleCallbacks` on package deactivation
* Bring in dependencies immediately in `lint()` if required

Sorry for the PR spam @wooorm, this was just one of the worst offenders for startup time so it was one of the first worked on. After implementing similar measures in 3 other packages now I think we've got all the issues covered here 😉.