### PR TITLE
chore(package): update atom-package-deps to version 4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "linter"
   ],
   "dependencies": {
-    "atom-package-deps": "^4.0.1",
+    "atom-package-deps": "^4.6.0",
     "remark": "7.0.0",
     "remark-preset-lint-consistent": "^2.0.0",
     "remark-preset-lint-recommended": "^2.0.0",


### PR DESCRIPTION
Explicitly updating to this version since it cuts the time to require this dependency by 3-4x. It's already moved to an idle callback, but why not make sure that runs as fast as possible as well? 😛