### PR TITLE
Update minimum Atom version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "repository": "https://github.com/AtomLinter/linter-markdown",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0.0 <2.0.0"
+    "atom": ">=1.7.0 <2.0.0"
   },
   "package-deps": [
     "linter"


### PR DESCRIPTION
Specifies the mimimum Atom version to be v1.7.0 for
`requestIdleCallback` support.

Fixes #135.