### PR TITLE
Global plugins and new preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,16 @@ If there is no configuration found for **remark-lint**, this linter runs [remark
 
 If there *is* configuration for **remark-lint**, through `.remarkrc` files
 or `remarkConfig` in `package.json`s, this linter works just like
-[remark-cli][cli] but only uses the **remark-lint** plugin. Make sure
-**remark-lint** is installed in this case (locally).
+[remark-cli][cli].
+
+You should probably install modules referenced in `.remarkrc` files locally
+(`npm install` without the `-g` or `--global` flag). If you do install modules
+globally, you must either use [nvm][], or have
+a [`prefix` in your `.npmrc`][prefix].
+
+See [this tutorial][set-up] on how to set-up npm to work without sudo, which
+is good practise, and comes with the added benefit that `linter-markdown`
+can pick up on globally installed modules.
 
 Read more about configuring [remark-lint][configuration] on its README.
 
@@ -38,3 +46,6 @@ We also maintain a [changelog][changelog] containing recent changes.
 [consistent]: https://github.com/wooorm/remark-lint/tree/master/packages/remark-preset-lint-consistent
 [recommended]: https://github.com/wooorm/remark-lint/tree/master/packages/remark-preset-lint-recommended
 [linter-remark]: https://github.com/wooorm/linter-remark
+[nvm]: https://github.com/creationix/nvm
+[prefix]: https://docs.npmjs.com/misc/config#prefix
+[set-up]: https://github.com/sindresorhus/guides/blob/master/npm-global-without-sudo.md

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Lint markdown files using [remark-lint][remark-lint] and the
 
 If there is no configuration found for **remark-lint**, this linter runs [remark-preset-lint-consistent][consistent] and
 [remark-preset-lint-recommended][recommended] (both can be turned off).
+You can a also turn on [remark-preset-lint-markdown-style-guide][styleguide].
 
 If there *is* configuration for **remark-lint**, through `.remarkrc` files
 or `remarkConfig` in `package.json`s, this linter works just like
@@ -45,6 +46,7 @@ We also maintain a [changelog][changelog] containing recent changes.
 [cli]: https://github.com/wooorm/remark/tree/master/packages/remark-cli
 [consistent]: https://github.com/wooorm/remark-lint/tree/master/packages/remark-preset-lint-consistent
 [recommended]: https://github.com/wooorm/remark-lint/tree/master/packages/remark-preset-lint-recommended
+[styleguide]: https://github.com/wooorm/remark-lint/tree/master/packages/remark-preset-lint-markdown-style-guide
 [linter-remark]: https://github.com/wooorm/linter-remark
 [nvm]: https://github.com/creationix/nvm
 [prefix]: https://docs.npmjs.com/misc/config#prefix

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,8 +17,10 @@ let processor;
 let subscriptions;
 let recommendedWithoutConfig;
 let consistentWithoutConfig;
+let styleGuideWithoutConfig;
 let recommended;
 let consistent;
+let styleGuide;
 const idleCallbacks = new Set();
 
 // Settings
@@ -34,6 +36,9 @@ function loadDeps() {
   }
   if (!recommended) {
     recommended = require('remark-preset-lint-recommended');
+  }
+  if (!styleGuide) {
+    styleGuide = require('remark-preset-lint-markdown-style-guide');
   }
   if (!consistent) {
     consistent = require('remark-preset-lint-consistent');
@@ -51,11 +56,15 @@ function lint(editor) {
     plugins.push(recommended);
   }
 
+  if (styleGuideWithoutConfig) {
+    plugins.push(styleGuide);
+  }
+
   if (consistentWithoutConfig) {
     plugins.push(consistent);
   }
 
-  if (consistentWithoutConfig || recommendedWithoutConfig) {
+  if (consistentWithoutConfig || recommendedWithoutConfig || styleGuideWithoutConfig) {
     defaultConfig = { plugins };
   }
 
@@ -109,6 +118,9 @@ function activate() {
   }));
   subscriptions.add(atom.config.observe('linter-markdown.presetConsistentWithoutConfig', (value) => {
     consistentWithoutConfig = value;
+  }));
+  subscriptions.add(atom.config.observe('linter-markdown.presetStyleGuideWithoutConfig', (value) => {
+    styleGuideWithoutConfig = value;
   }));
   subscriptions.add(atom.config.observe('linter-markdown.scopes', (value) => {
     scopes = value;

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "atom-package-deps": "^4.6.0",
     "remark": "7.0.1",
     "remark-preset-lint-consistent": "^2.0.0",
+    "remark-preset-lint-markdown-style-guide": "^1.0.0",
     "remark-preset-lint-recommended": "^2.0.0",
     "unified-engine-atom": "^5.0.0"
   },
@@ -87,6 +88,12 @@
       "description": "Use [remark-preset-lint-consistent](https://github.com/wooorm/remark-lint/tree/master/packages/remark-preset-lint-consistent) if no **remark-lint** config is found.",
       "type": "boolean",
       "default": true
+    },
+    "presetStyleGuideWithoutConfig": {
+      "title": "Strict markdown style guide by default",
+      "description": "Use [remark-preset-lint-markdown-style-guide](https://github.com/wooorm/remark-lint/tree/master/packages/remark-preset-lint-markdown-style-guide) if no **remark-lint** config is found.",
+      "type": "boolean",
+      "default": false
     },
     "scopes": {
       "title": "Scopes",


### PR DESCRIPTION
Hi folks! 👋

I just added support for a preset to check the [Markdown Style Guide](http://www.cirosantilli.com/markdown-style-guide/) that people can enable.

Additionally, globally installed modules [now work](https://github.com/wooorm/load-plugin/compare/34289da...dc0cf45). That was [quite difficult](https://github.com/eush77/npm-prefix/issues/1) to get working because Electron/Atom runs a different version of Node/npm than the one those modules are installed with.

Global modules do require some set-up, and I added docs for that in the README.md.

Let me know how this looks!

/cc @Arcanemagus 