### PR TITLE
Add support for YAML frontmatter by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Lint markdown files using [remark-lint][remark-lint] and the
 If there is no configuration found for **remark-lint**, this linter runs [remark-preset-lint-consistent][consistent] and
 [remark-preset-lint-recommended][recommended] (both can be turned off).
 You can a also turn on [remark-preset-lint-markdown-style-guide][styleguide].
+By default, [YAML frontmatter][yaml] is supported, but you can turn that off.
 
 If there *is* configuration for **remark-lint**, through `.remarkrc` files
 or `remarkConfig` in `package.json`s, this linter works just like
@@ -44,6 +45,7 @@ We also maintain a [changelog][changelog] containing recent changes.
 [linter]: https://atom.io/packages/linter
 [screenshot]: https://raw.githubusercontent.com/AtomLinter/linter-markdown/master/assets/screenshot.png
 [cli]: https://github.com/wooorm/remark/tree/master/packages/remark-cli
+[yaml]: https://github.com/wooorm/remark-frontmatter
 [consistent]: https://github.com/wooorm/remark-lint/tree/master/packages/remark-preset-lint-consistent
 [recommended]: https://github.com/wooorm/remark-lint/tree/master/packages/remark-preset-lint-recommended
 [styleguide]: https://github.com/wooorm/remark-lint/tree/master/packages/remark-preset-lint-markdown-style-guide

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,9 +15,11 @@ import { CompositeDisposable } from 'atom';
 let engine;
 let processor;
 let subscriptions;
+let yamlWithoutConfig;
 let recommendedWithoutConfig;
 let consistentWithoutConfig;
 let styleGuideWithoutConfig;
+let frontmatter;
 let recommended;
 let consistent;
 let styleGuide;
@@ -33,6 +35,9 @@ function loadDeps() {
   }
   if (!processor) {
     processor = require('remark');
+  }
+  if (!frontmatter) {
+    frontmatter = require('remark-frontmatter');
   }
   if (!recommended) {
     recommended = require('remark-preset-lint-recommended');
@@ -52,6 +57,10 @@ function lint(editor) {
   // Load required modules if not already handled by init
   loadDeps();
 
+  if (yamlWithoutConfig) {
+    plugins.push(frontmatter);
+  }
+
   if (recommendedWithoutConfig) {
     plugins.push(recommended);
   }
@@ -64,7 +73,12 @@ function lint(editor) {
     plugins.push(consistent);
   }
 
-  if (consistentWithoutConfig || recommendedWithoutConfig || styleGuideWithoutConfig) {
+  if (
+    yamlWithoutConfig ||
+    consistentWithoutConfig ||
+    recommendedWithoutConfig ||
+    styleGuideWithoutConfig
+  ) {
     defaultConfig = { plugins };
   }
 
@@ -113,6 +127,9 @@ function activate() {
 
   subscriptions = new CompositeDisposable();
 
+  subscriptions.add(atom.config.observe('linter-markdown.yamlWithoutConfig', (value) => {
+    yamlWithoutConfig = value;
+  }));
   subscriptions.add(atom.config.observe('linter-markdown.presetRecommendedWithoutConfig', (value) => {
     recommendedWithoutConfig = value;
   }));

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "atom-package-deps": "^4.6.0",
     "remark": "8.0.0",
+    "remark-frontmatter": "^1.1.0",
     "remark-preset-lint-consistent": "^2.0.0",
     "remark-preset-lint-markdown-style-guide": "^2.0.0",
     "remark-preset-lint-recommended": "^3.0.0",
@@ -74,6 +75,12 @@
     "detectIgnore": {
       "title": "Ignore files",
       "description": "Use `.remarkignore` files.",
+      "type": "boolean",
+      "default": true
+    },
+    "yamlWithoutConfig": {
+      "title": "Support YAML frontmatter",
+      "description": "Support YAML [frontmatter](https://github.com/wooorm/remark-frontmatter) if no **remark-lint** config is found.",
       "type": "boolean",
       "default": true
     },


### PR DESCRIPTION
...and support turning it off in the settings.

Previously, before 5.0.0, YAML was always supported but in [`remark@8.0.0`](https://github.com/wooorm/remark/releases/tag/8.0.0) that is no longer the case.

Closes GH-148.