### PR TITLE
Enable `detectConfig` to search for .js/yaml config files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,6 +84,7 @@ function lint(editor) {
 
   return engine({
     processor,
+    detectConfig: true,
     detectIgnore,
     defaultConfig,
     rcName: '.remarkrc',


### PR DESCRIPTION
This enables the `detectConfig` option so that other config files than _.remarkrc_ will be understood. Without this option, ie. _.remarkrc.js_ is not loaded when using the linter plugin and default rules are used instead.