### PR TITLE
Initial Adoption of Continous Deployment using semantic-release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .DS_Store
 npm-debug.log
 node_modules
-.github_changelog_generator

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,3 +47,15 @@ addons:
     - git
     - libgnome-keyring-dev
     - fakeroot
+
+node_js: lts/*
+
+after_success:
+  # Add apm to the PATH
+  - export PATH=${PATH}:${HOME}/atom/usr/bin/
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script:
+    - npx semantic-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,43 @@
 ### Project specific config ###
 language: node_js
+node_js: lts/*
+os: linux
 
-node_js:
-  - '4'
-  - '6'
+jobs:
+  include:
+    # Test PHP versions
+    - stage: test
+      env: ATOM_CHANNEL=stable
+    - stage: test
+      env: ATOM_CHANNEL=beta
 
-env:
-  global:
-    - ATOM_LINT_WITH_BUNDLED_NODE="false"
+    # Check the commit messages and run the extra lint script
+    - stage: test
+      language: node_js
+      node_js: lts/*
+      install:
+        - npm install
+      script:
+        - npm run lint
+        - commitlint-travis
 
-os:
-  - linux
-
-after_script:
-  - npm run lint
+    - stage: release
+      # Since the deploy needs APM, currently the simplest method is to run
+      # build-package.sh, which requires the specs to pass, so this must run in
+      # the main language instead of Node.js.
+      before_script:
+        - export PATH=${PATH}:${HOME}/atom/usr/bin/
+      deploy:
+        provider: script
+        skip_cleanup: true
+        script:
+          - npx semantic-release
 
 ### Generic setup follows ###
 script:
   - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
   - chmod u+x build-package.sh
-  - ./build-package.sh
-
-# Needed to disable the auto-install step running `npm install`
-install: true
+  - "./build-package.sh"
 
 notifications:
   email:
@@ -32,6 +47,7 @@ notifications:
 branches:
   only:
     - master
+    - "/^greenkeeper/.*$/"
 
 git:
   depth: 10
@@ -48,14 +64,7 @@ addons:
     - libgnome-keyring-dev
     - fakeroot
 
-node_js: lts/*
-
-after_success:
-  # Add apm to the PATH
-  - export PATH=${PATH}:${HOME}/atom/usr/bin/
-
-deploy:
-  provider: script
-  skip_cleanup: true
-  script:
-    - npx semantic-release
+stages:
+  - test
+  - name: release
+    if: (NOT type = pull_request) AND branch = master

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
     "remark-lint",
     "markdown"
   ],
-  "repository": "https://github.com/AtomLinter/linter-markdown",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/AtomLinter/linter-markdown.git"
+  },
   "license": "MIT",
   "engines": {
     "atom": ">=1.7.0 <2.0.0"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "5.2.0",
   "description": "Lint markdown on the fly, using remark-lint",
   "scripts": {
+    "commitmsg": "commitlint -e $GIT_PARAMS",
     "lint": "remark README.md LICENSE.md && eslint lib spec",
     "test": "apm test"
   },
@@ -32,6 +33,12 @@
     "unified-engine-atom": "^5.0.0"
   },
   "devDependencies": {
+    "@commitlint/cli": "^6.1.3",
+    "@commitlint/config-conventional": "^6.1.3",
+    "@commitlint/travis-cli": "^6.1.3",
+    "@semantic-release/apm-config": "^2.0.1",
+    "husky": "^0.14.3",
+    "semantic-release": "^15.1.7",
     "eslint": "^4.6.0",
     "eslint-config-airbnb-base": "^12.0.0",
     "eslint-plugin-import": "^2.7.0",
@@ -115,5 +122,13 @@
         "text.md"
       ]
     }
+  },
+  "release": {
+    "extends": "@semantic-release/apm-config"
+  },
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
   }
 }


### PR DESCRIPTION
To ease the modification/contribution to publish pipeline there has been some discussion of adopting a continuous deployment system for AtomLinter packages. To accomplish this we are making use of [`semantic-release`](https://github.com/semantic-release/semantic-release) and [`@semantic-release/apm-config`](https://github.com/semantic-release/apm-config).

This pull request has been [dynamically created using a script](https://gist.github.com/keplersj/8bc7622ea741c0964d12842bfc679c5d). While the result is not perfect, it does accompish most of the grunt work of adopting continous deployment. There is some reconciliation that needs to be done before this can be merged.

Among the things needed to be reconciled, an [APM Token](https://atom.io/account) and [GitHub Token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) will need to be added to this repo's continous integration (most likely [Travis CI](https://docs.travis-ci.com/user/environment-variables#Defining-Variables-in-Repository-Settings)) configuration for automated deployments to work.

Again, this Pull Request has been created by a script made by @keplersj. Please mention him if something has gone wrong, and he'll be happy to help.

ref: AtomLinter/Meta#18

cc: @Arcanemagus
