### PR TITLE
Update CircleCI cache strategy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,6 @@ defaults: &defaults
         name: APM version
         command: ${APM_SCRIPT_PATH} --version
     - run:
-        name: Cleaning package
-        command: ${APM_SCRIPT_PATH} clean
-    - run:
         name: Package APM package dependencies
         command: |
           if [ -n "${APM_TEST_PACKAGES}" ]; then
@@ -32,13 +29,16 @@ defaults: &defaults
         name: Package dependencies
         command: ${APM_SCRIPT_PATH} install
     - run:
+        name: Cleaning package
+        command: ${APM_SCRIPT_PATH} clean
+    - run:
         name: Package specs
         command: ${ATOM_SCRIPT_PATH} --test spec
     # Cache node_modules
     - save_cache:
         paths:
           - node_modules
-        key: v1-dependencies-{{ checksum "package.json" }}
+        key: v1-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
 
 jobs:
   checkout_code:
@@ -50,10 +50,15 @@ jobs:
       # Restore node_modules from the last build
       - restore_cache:
           keys:
-          # Get latest cache for this package.json
-          - v1-dependencies-{{ checksum "package.json" }}
-          # Fallback to the last available cache
-          - v1-dependencies
+          # Get latest cache for this package.json and package-lock.json
+          - v1-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-{{ checksum "package-lock.json"}}
+          # Fallback to the current package.json
+          - v1-dependencies-{{ .Branch }}-{{ checksum "package.json" }}-
+          # Fallback to the last build for this branch
+          - v1-dependencies-{{ .Branch }}-
+          # Fallback to the last available master branch cache
+          - v1-dependencies-master-
+          # Don't go further down to prevent dependency issues from other branches
       # Save project state for next steps
       - persist_to_workspace:
           root: /tmp


### PR DESCRIPTION
Update the caching strategy in CircleCI to prevent cross-contamination between branches.

Also moves the `apm clean` step after `apm install` to prevent a related issue.